### PR TITLE
Terraform fixes and environment variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,8 @@ jobs:
           mkdir -p layer/python
           mkdir -p .remote_deployment
           pip install -r layer_requirements.txt -t layer/python/
-          zip -r ./.remote_deployment/layer_requests.zip layer/python
+          cd layer
+          zip -r ../.remote_deployment/layer_requests.zip python
 
       - name: Terraform Plan
         working-directory: terraform

--- a/src/extract/extract.py
+++ b/src/extract/extract.py
@@ -8,9 +8,6 @@ from extract_utils import (
     create_directory_structure_and_file_name,
     store_in_s3
 )
-from dotenv import load_dotenv
-
-load_dotenv()
 
 data_bucket = os.environ.get("INGESTION_BUCKET")
 code_bucket = os.environ.get("CODE_BUCKET")

--- a/src/extract/extract_utils.py
+++ b/src/extract/extract_utils.py
@@ -6,9 +6,6 @@ import os
 import csv
 import io
 
-from dotenv import load_dotenv
-load_dotenv()
-
 def make_api_get_request():
     """
     Makes API get request to OpenWeatherMap API.

--- a/terraform/cloudwatch-extract.tf
+++ b/terraform/cloudwatch-extract.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "extract_log_group" {
-    name                = "/aws/lambda/extract"
+    name                = "/aws/lambda/${aws_lambda_function.lambda_extract.function_name}"
     retention_in_days   = 30 # ADJUST AS NECESSARY
     tags                =  {
         name        = "Extract Lambda log group"

--- a/terraform/lambda-extract.tf
+++ b/terraform/lambda-extract.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "lambda_extract" {
     s3_bucket           = aws_s3_bucket.s3_code.bucket
     s3_key              = "lambda_extract.zip"
     role                = aws_iam_role.extract_role.arn
-    handler             = "lambda_handler.lambda_handler"
+    handler             = "extract.lambda_handler"
     timeout             = 180
     source_code_hash    = data.archive_file.lambda_extract.output_base64sha256
     runtime             = "python3.12"

--- a/terraform/lambda-extract.tf
+++ b/terraform/lambda-extract.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "lambda_extract" {
     source_code_hash    = data.archive_file.lambda_extract.output_base64sha256
     runtime             = "python3.12"
     layers              = [aws_lambda_layer_version.layer_requests.arn]
-    depends_on          = [aws_cloudwatch_log_group.extract_log_group]
+    depends_on          = [aws_lambda_layer_version.layer_requests.arn]
     environment {
       variables = {
             api_key             = var.openweather_api_key

--- a/terraform/lambda-extract.tf
+++ b/terraform/lambda-extract.tf
@@ -8,12 +8,12 @@ resource "aws_lambda_function" "lambda_extract" {
     source_code_hash    = data.archive_file.lambda_extract.output_base64sha256
     runtime             = "python3.12"
     layers              = [aws_lambda_layer_version.layer_requests.arn]
-    depends_on          = [aws_lambda_layer_version.layer_requests.arn]
+    depends_on          = [aws_lambda_layer_version.layer_requests]
     environment {
       variables = {
-            api_key             = var.openweather_api_key
-            ingestion_bucket    = aws_s3_bucket.s3_ingestion.bucket
-            code_bucket         = aws_s3_bucket.s3_code.bucket
+            API_KEY             = var.openweather_api_key
+            INGESTION_BUCKET    = aws_s3_bucket.s3_ingestion.bucket
+            CODE_BUCKET         = aws_s3_bucket.s3_code.bucket
       }
     } 
 }

--- a/terraform/layer.tf
+++ b/terraform/layer.tf
@@ -3,4 +3,5 @@ resource "aws_lambda_layer_version" "layer_requests" {
     description     = "Installs Python Requests library"
     s3_bucket       = aws_s3_object.layer_requests.bucket
     s3_key          = aws_s3_object.layer_requests.key
+    source_code_hash = filebase64sha256(var.layer_requests_file)
 }


### PR DESCRIPTION
Adjusted names of environment variables in Terraform (changed to upper case) to match Python code (they are case sensitive apparently).

Fixed Cloudwatch naming convention so lambda actually logs to correct cloudwatch event logs.

Fixed lambda_handler address so it uses the correct lambda handler function as an entrypoint.

Remove dotenv module and calls because no .env file is being used in AWS. (May need to move this into pytest instead if still necessary on local machines?)